### PR TITLE
Fix flatten unicode

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -219,9 +219,10 @@ def flatten(items):
 
     http://docs.python.org/3.4/library/itertools.html#itertools-recipes
     """
+    str_type = basestring if version_info[0] < 3 else str
     for item in items:
         is_iterable = isinstance(item, Iterable)
-        is_string_or_bytes = isinstance(item, (str, bytes, bytearray))
+        is_string_or_bytes = isinstance(item, (str_type, bytes, bytearray))
         if is_iterable and not is_string_or_bytes:
             for i in flatten(item):
                 yield i

--- a/tests.py
+++ b/tests.py
@@ -621,11 +621,13 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertEqual([1,1,2,1,2,3], list(iters.flatten(generators)))
         # flat list should return itself
         self.assertEqual([1,2,3], list(iters.flatten([1,2,3])))
-        # Don't flatten strings, bytes, or bytearrays
+        # Don't flatten strings/unicode, bytes, or bytearrays
         self.assertEqual([2,"abc",1], list(iters.flatten([2,"abc",1])))
         self.assertEqual([2, b'abc', 1], list(iters.flatten([2, b'abc', 1])))
         self.assertEqual([2, bytearray(b'abc'), 1],
                          list(iters.flatten([2, bytearray(b'abc'), 1])))
+        self.assertEqual([bytearray(b'abc'), b'\xd1\x8f'.decode('utf8'), b'y'],
+                         list(iters.flatten([bytearray(b'abc'), b'\xd1\x8f'.decode('utf8'), b'y'])))
 
     def test_accumulate(self):
         self.assertEqual([1,3,6,10,15], list(iters.accumulate([1,2,3,4,5])))


### PR DESCRIPTION
###### (copied from the original repo -- see https://github.com/kachayev/fn.py/pull/78)

`is_string_or_bytes` checks for `str` instances which is correct only for python3
while in python2 the right type is `basestring`.

Fixes https://github.com/kachayev/fn.py/issues/73

Bug demo in the build after adding tests.