### PR TITLE
Fix doctest error

### DIFF
--- a/fn/underscore.py
+++ b/fn/underscore.py
@@ -80,7 +80,7 @@ class _Callable(object):
         )
 
     def __getattr__(self, name):
-        if name == '__wrapped__': # Guard for recursive call by doctest
+        if name == '__wrapped__':  # Guard for recursive call by doctest
             raise AttributeError
         attr_name = _random_name()
         return self.__class__(

--- a/fn/underscore.py
+++ b/fn/underscore.py
@@ -80,6 +80,8 @@ class _Callable(object):
         )
 
     def __getattr__(self, name):
+        if name == '__wrapped__': # Guard for recursive call by doctest
+            raise AttributeError
         attr_name = _random_name()
         return self.__class__(
             F(operator.attrgetter(name)) << F(self),

--- a/test.py
+++ b/test.py
@@ -1,6 +1,11 @@
+import doctest
 import unittest
 
 from tests import *
 
 if __name__ == "__main__":
+
+    import tests.test_doctest
+    doctest.testmod(tests.test_doctest)
+
     unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 from .test_banker_queue import *
 from .test_composition import *
 from .test_curry import *
+from .test_doctest import *
 from .test_finger_tree import *
 from .test_iterators import *
 from .test_linked import *

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,0 +1,1 @@
+from fn import _


### PR DESCRIPTION
Introduce guard for recursive call by doctest.

https://stackoverflow.com/questions/49271586/valueerror-wrapper-loop-when-unwrapping