### PR TITLE
rewrite recur.tco as a function (with fix for RecursionError)

### DIFF
--- a/fn/recur.py
+++ b/fn/recur.py
@@ -28,7 +28,7 @@ def tco(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        action = func
+        action = wrapper
         while True:
             result = action.__wrapped__(*args, **kwargs)
             # return final result
@@ -46,8 +46,6 @@ def tco(func):
 
     # @wraps does not set __wrapped__ in py2
     wrapper.__wrapped__ = func
-    # make sure that the wrapper sees changes to func
-    func = wrapper
     return wrapper
 
 

--- a/fn/recur.py
+++ b/fn/recur.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 
 
-class tco(object):
+def tco(func):
     """Provides a trampoline for functions that need one.
 
     Such function should return one of:
@@ -25,15 +25,10 @@ class tco(object):
     http://mail.python.org/pipermail/python-ideas/2009-May/004486.html
     """
 
-    __slots__ = "func",
-
-    def __init__(self, func):
-        self.func = func
-
-    def __call__(self, *args, **kwargs):
-        action = self
+    def wrapped(*args, **kwargs):
+        action = func
         while True:
-            result = action.func(*args, **kwargs)
+            result = action(*args, **kwargs)
             # return final result
             if not result[0]:
                 return result[1]
@@ -46,7 +41,7 @@ class tco(object):
             if callable(act):
                 action = act
             kwargs = result[2] if len(result) > 2 else {}
-
+    return wrapped
 
 class stackless(object):
     """Provides a "stackless" (constant Python stack space) recursion

--- a/test.py
+++ b/test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import doctest
 import unittest
 


### PR DESCRIPTION
Fixes #35.
I have tested it using timeit and have determined that this function is no slower than the class-based version.