### PR TITLE
Added supporting to type hint in curried decorator

### DIFF
--- a/fn/monad.py
+++ b/fn/monad.py
@@ -48,9 +48,9 @@ You need to evaluate "request type" using at least on attribute:
     from fn.monad import Option
 
     request = dict(url="face.png", mimetype="PNG")
-    tp = Option(request.get("type", None)) \ # check "type" key first
-      .or_call(from_mimetype, request) \ # or.. check "mimetype" key
-      .or_call(from_extension, request) \ # or... get "url" and check extension
+    tp = Option(request.get("type", None)) \\ # check "type" key first
+      .or_call(from_mimetype, request) \\ # or... check "mimetype" key
+      .or_call(from_extension, request) \\# or... get "url" and check extension
       .get_or("application/undefined")
 
 """

--- a/tests/test_curry.py
+++ b/tests/test_curry.py
@@ -38,7 +38,13 @@ class Curriedtest(unittest.TestCase):
         def _custom_sum(a, b, c, d):
             return a + b + c + d
 
-        _custom_sum.__annotations__ = {'a': int, 'b': int, 'c': int, 'd': int, 'return': int}
+        _custom_sum.__annotations__ = {
+                                        'a': int,
+                                        'b': int,
+                                        'c': int,
+                                        'd': int,
+                                        'return': int
+                                      }
 
         custom_sum = curried(_custom_sum)
 

--- a/tests/test_curry.py
+++ b/tests/test_curry.py
@@ -1,9 +1,16 @@
 import unittest
 
-from fn.func import curried
+from fn.func import curried, _has_type_hint_support
 
 
 class Curriedtest(unittest.TestCase):
+
+    def _assert_instance(self, expected, acutal):
+        self.assertEqual(expected.__module__, acutal.__module__)
+        self.assertEqual(expected.__name__, acutal.__name__)
+
+        if _has_type_hint_support:
+            self.assertEqual(expected.__annotations__, acutal.__annotations__)
 
     def test_curried_wrapper(self):
 
@@ -15,16 +22,32 @@ class Curriedtest(unittest.TestCase):
         def _moma(a, b):
             return _child(a, b)
 
-        def _assert_instance(expected, acutal):
-            self.assertEqual(expected.__module__, acutal.__module__)
-            self.assertEqual(expected.__name__, acutal.__name__)
-
         res1 = _moma(1)
-        _assert_instance(_moma, res1)
+        self._assert_instance(_moma, res1)
         res2 = res1(2)
-        _assert_instance(_child, res2)
+        self._assert_instance(_child, res2)
         res3 = res2(3)
-        _assert_instance(_child, res3)
+        self._assert_instance(_child, res3)
+        res4 = res3(4)
+
+        self.assertEqual(res4, 10)
+
+    @unittest.skipIf(not _has_type_hint_support, "Type hint aren't supported")
+    def test_curried_with_annotations_when_they_are_supported(self):
+
+        def _custom_sum(a, b, c, d):
+            return a + b + c + d
+
+        _custom_sum.__annotations__ = {'a': int, 'b': int, 'c': int, 'd': int, 'return': int}
+
+        custom_sum = curried(_custom_sum)
+
+        res1 = custom_sum(1)
+        self._assert_instance(custom_sum, res1)
+        res2 = res1(2)
+        self._assert_instance(custom_sum, res2)
+        res3 = res2(3)
+        self._assert_instance(custom_sum, res3)
         res4 = res3(4)
 
         self.assertEqual(res4, 10)


### PR DESCRIPTION
This pull-request closes #29. 

Adding supporting to type hint in curried decorator only if python version is greater than or equal to 3.5.

