### PR TITLE
Import `Iterable` from `collections.abc` for >=3.8.

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -1,4 +1,4 @@
-from collections import Iterable, deque
+from collections import deque
 from functools import partial
 from itertools import (chain, combinations, cycle, dropwhile, islice, repeat,
                        starmap, takewhile, tee)
@@ -7,7 +7,7 @@ from sys import version_info
 
 from .func import F
 from .op import flip
-from .uniform import filterfalse, zip_longest, map, range, filter
+from .uniform import filterfalse, zip_longest, map, range, filter, Iterable
 
 
 def take(limit, base):

--- a/fn/monad.py
+++ b/fn/monad.py
@@ -48,10 +48,10 @@ You need to evaluate "request type" using at least on attribute:
     from fn.monad import Option
 
     request = dict(url="face.png", mimetype="PNG")
-    tp = Option(request.get("type", None)) \ # check "type" key first
-      .or_call(from_mimetype, request) \ # or.. check "mimetype" key
-      .or_call(from_extension, request) \ # or... get "url" and check extension
-      .get_or("application/undefined")
+    tp = (Option(request.get("type", None)) # check "type" key first
+      .or_call(from_mimetype, request) # or.. check "mimetype" key
+      .or_call(from_extension, request) # or... get "url" and check extension
+      .get_or("application/undefined"))
 
 """
 

--- a/fn/uniform.py
+++ b/fn/uniform.py
@@ -22,3 +22,10 @@ if version_info[0] == 2:
 else:
     from itertools import filterfalse
     from itertools import zip_longest
+
+# Using or importing the ABCs from 'collections' instead of from
+# 'collections.abc' is deprecated, and in 3.8 it will stop working.
+if version_info[0] <= 3 and version_info[1] < 8:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable


### PR DESCRIPTION
https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable

Below is the warning message triggered using any modules in fn.iters
from Python 3.7.

    fn/iters.py:2: DeprecationWarning: Using or importing the ABCs
    from 'collections' instead of from 'collections.abc' is
    deprecated, and in 3.8 it will stop working

        from collections import deque, Iterable

    -- Docs: https://docs.pytest.org/en/latest/warnings.html