### PR TITLE
collections -> collections.abc

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -1,4 +1,5 @@
 from collections import deque
+from collections.abc import Iterable
 from functools import partial
 from itertools import (chain, combinations, cycle, dropwhile, islice, repeat,
                        starmap, takewhile, tee)


### PR DESCRIPTION
fixes DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working