### PR TITLE
Add optional property to Option, which is functionally equivalent to …

### DIFF
--- a/fn/monad.py
+++ b/fn/monad.py
@@ -102,6 +102,10 @@ class Option(object):
     def or_call(self, callback, *args, **kwargs):
         raise NotImplementedError()
 
+    @property
+    def optional(self):
+        raise NotImplementedError()
+
 
 class Full(Option):
     """Represents value that is ready for further computations"""
@@ -136,6 +140,10 @@ class Full(Option):
 
     def or_call(self, callback, *args, **kwargs):
         return self
+
+    @property
+    def optional(self):
+        return self.x
 
     def __str__(self):
         return "Full(%s)" % self.x
@@ -176,6 +184,10 @@ class Empty(Option):
 
     def or_call(self, callback, *args, **kwargs):
         return Option(callback(*args, **kwargs))
+
+    @property
+    def optional(self):
+        return None
 
     def __str__(self):
         return "Empty()"


### PR DESCRIPTION
…calling get_or(None).

Hi, not sure how you feel about this but I basically just use `Option` as a functor, so I often have code with a sequence of calls to `map`, with a final call of `.get_or(None)` to return to the Python `Optional` type. This is just a convenient shorthand for that use case.